### PR TITLE
Add pqc_stats to pico_pqc_sdk

### DIFF
--- a/Pi-Pico/pico_pqc_sdk/examples/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(test_stats)
 add_subdirectory(test_timers)

--- a/Pi-Pico/pico_pqc_sdk/examples/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(test_stats)
 add_subdirectory(test_timers)
+add_subdirectory(test_csv)

--- a/Pi-Pico/pico_pqc_sdk/examples/test_csv/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/examples/test_csv/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test_csv test_csv.c)
+
+target_link_libraries(test_csv PUBLIC
+    pqc_stats)
+
+pico_add_extra_outputs(test_csv)
+
+pico_enable_stdio_usb(test_stats 0)
+pico_enable_stdio_uart(test_stats 1)

--- a/Pi-Pico/pico_pqc_sdk/examples/test_csv/test_csv.c
+++ b/Pi-Pico/pico_pqc_sdk/examples/test_csv/test_csv.c
@@ -1,0 +1,57 @@
+#include "pqc-pico/stats.h"
+
+stat_obj_t* rand_obj(size_t num, int conf_pc){
+    //track random number statistic
+    stat_t* rand_stat = (stat_t*) malloc(sizeof(stat_t));
+    init_stat(rand_stat);
+    size_t nobj = 20;
+    for(size_t n = 0; n < nobj; ++n){
+        add_stat(rand_stat, rand() % 100);
+    }
+    //store stats in object
+    stat_obj_t* obj = (stat_obj_t*) malloc(sizeof(stat_obj_t));
+    char snum[5];
+    snprintf(snum,sizeof snum,"%zu", num);
+    char sconf[5];
+    snprintf(sconf,sizeof sconf, "%d", conf_pc);
+    char rand[] = "RAND_p=0.";
+    char* rowlabel = strcat(rand,sconf);
+    rowlabel = strcat(rowlabel,"_");
+    rowlabel = strcat(rand,snum);
+    init_statobj(obj,rowlabel,rand_stat,conf_pc);
+    free_stat(rand_stat);
+    return obj;
+}
+
+int main(){
+    stdio_init_all();
+    busy_wait_ms(30);
+
+    char header_95[] = "RAND_0.95";
+    char header_99[] = "RAND_0.99";
+    char header_999[] = "RAND_0.999";
+    csv_t* csv_95 = (csv_t*) malloc(sizeof(csv_t));
+    csv_t* csv_99 = (csv_t*) malloc(sizeof(csv_t));
+    csv_t* csv_999 = (csv_t*) malloc(sizeof(csv_t));
+    init_csv(csv_95,header_95);
+    init_csv(csv_99,header_99);
+    init_csv(csv_999,header_999);
+
+    size_t nrow = 11;
+    for(size_t n = 1; n<nrow; ++n){
+        stat_obj_t* rand_so_95 = rand_obj(n,95);
+        stat_obj_t* rand_so_99 = rand_obj(n,99);
+        stat_obj_t* rand_so_999 = rand_obj(n,999);
+        add_csv(csv_95,rand_so_95);
+        add_csv(csv_99,rand_so_99);
+        add_csv(csv_999,rand_so_999);
+    }
+    print_csv(csv_95);
+    print_csv(csv_99);
+    print_csv(csv_999);
+
+    free_csv(csv_95);
+    free_csv(csv_99);
+    free_csv(csv_999);
+    return 0;
+}

--- a/Pi-Pico/pico_pqc_sdk/examples/test_stats/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/examples/test_stats/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test_stats test_stats.c)
+
+target_link_libraries(test_stats PUBLIC
+    pqc_stats)
+
+pico_add_extra_outputs(test_stats)
+
+pico_enable_stdio_usb(test_stats 0)
+pico_enable_stdio_uart(test_stats 1)

--- a/Pi-Pico/pico_pqc_sdk/examples/test_stats/test_stats.c
+++ b/Pi-Pico/pico_pqc_sdk/examples/test_stats/test_stats.c
@@ -1,0 +1,21 @@
+#include "pqc-pico/stats.h"
+
+int main(){
+    stdio_init_all();
+    busy_wait_ms(300);
+    
+    
+    stat_t* s = (stat_t*) malloc(sizeof(stat_t));
+    init_stat(s);
+
+    add_stat(s,3.3);
+    add_stat(s,5.5769);
+    add_stat(s,10);
+    add_stat(s,6.53);
+    add_stat(s,1.153);
+    
+    print_stat(s);
+    print_conf_stat(s,95);
+    free_stat(s);
+    return 0;
+}

--- a/Pi-Pico/pico_pqc_sdk/examples/test_timers/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/examples/test_timers/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_executable(test_timers
-    test_timers.c
-    )
+add_executable(test_timers test_timers.c)
 
 target_link_libraries(test_timers PUBLIC 
     pqc_utimer

--- a/Pi-Pico/pico_pqc_sdk/src/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(pqc_utimer)
 add_subdirectory(pqc_systick)
 add_subdirectory(pqc_flash)
+add_subdirectory(pqc_stats)

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/CMakeLists.txt
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/CMakeLists.txt
@@ -1,0 +1,12 @@
+if(NOT TARGET pqc_stats_headers)
+    add_library(pqc_stats_headers INTERFACE)
+    target_include_directories(pqc_stats_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_link_libraries(pqc_stats_headers INTERFACE pico_stdlib)
+endif()
+
+if(NOT TARGET pqc_stats)
+    add_library(pqc_stats INTERFACE)
+    target_compile_definitions(pqc_stats INTERFACE LIB_PQC_STATS=1)
+    target_sources(pqc_stats INTERFACE ${CMAKE_CURRENT_LIST_DIR}/stats.c)
+    target_link_libraries(pqc_stats INTERFACE pqc_stats_headers)
+endif()

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
@@ -9,6 +9,14 @@ typedef struct {
     size_t n;
 } stat_t;
 
+typedef struct {
+    float mean;
+    float sd;
+    int p;
+    float ci;
+    size_t n;
+} stat_obj_t;
+
 void init_stat(stat_t* st);
 void add_stat(stat_t* st, float x);
 extern float mean_stat(stat_t* st);
@@ -17,3 +25,7 @@ float conf_stat(stat_t* st, int conf_pc);
 extern void print_stat(stat_t* st);
 extern void print_conf_stat(stat_t* st, int conf_pc);
 void free_stat(stat_t* st);
+
+void init_statobj(stat_obj_t* so, stat_t* st, int conf_pc);
+void print_statobj(stat_obj_t* so);
+void free_statobj(stat_obj_t* so);

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
@@ -1,7 +1,10 @@
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include "pico/stdlib.h"
+
+#define HEADER_PARTIAL_STATOBJ_CSV ", MEAN, CI, P, N\n"
 
 typedef struct {
     float x;
@@ -10,12 +13,19 @@ typedef struct {
 } stat_t;
 
 typedef struct {
+    char* label;
     float mean;
     float sd;
-    int p;
     float ci;
+    int p;
     size_t n;
 } stat_obj_t;
+
+typedef struct {
+    char* HEADER_LABEL;
+    size_t size_so_l;
+    stat_obj_t** so_l;
+} csv_t;
 
 void init_stat(stat_t* st);
 void add_stat(stat_t* st, float x);
@@ -26,6 +36,12 @@ extern void print_stat(stat_t* st);
 extern void print_conf_stat(stat_t* st, int conf_pc);
 void free_stat(stat_t* st);
 
-void init_statobj(stat_obj_t* so, stat_t* st, int conf_pc);
+void init_statobj(stat_obj_t* so, const char* label, stat_t* st, int conf_pc);
 void print_statobj(stat_obj_t* so);
+void print_statobj_csv(stat_obj_t* so);
 void free_statobj(stat_obj_t* so);
+
+void init_csv(csv_t* csv, char* HEADER_LABEL);
+void add_csv(csv_t* csv, stat_obj_t* so);
+void print_csv(csv_t* csv);
+void free_csv(csv_t* csv);

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/include/pqc-pico/stats.h
@@ -1,0 +1,19 @@
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+typedef struct {
+    float x;
+    float x2;
+    size_t n;
+} stat_t;
+
+void init_stat(stat_t* st);
+void add_stat(stat_t* st, float x);
+extern float mean_stat(stat_t* st);
+extern float sd_stat(stat_t* st);
+float conf_stat(stat_t* st, int conf_pc);
+extern void print_stat(stat_t* st);
+extern void print_conf_stat(stat_t* st, int conf_pc);
+void free_stat(stat_t* st);

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/stats.c
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/stats.c
@@ -54,3 +54,24 @@ inline void print_conf_stat(stat_t* st, int conf_pc){
 void free_stat(stat_t* st){
     free(st);
 }
+
+void init_statobj(stat_obj_t* so, stat_t* st, int conf_pc){
+    so->mean = mean_stat(st);
+    so->sd = sd_stat(st);
+    so->p = conf_pc;
+    so->ci = conf_stat(st,conf_pc);
+    so->n = st->n;
+}
+
+void print_statobj(stat_obj_t* so){
+    printf("mean=%f,sd=%f,ci=%f,p=0.%d,n=%zu\n",
+        so->mean,
+        so->sd,
+        so->ci,
+        so->p,
+        so->n);
+}
+
+void free_statobj(stat_obj_t* so){
+    free(so);
+}

--- a/Pi-Pico/pico_pqc_sdk/src/pqc_stats/stats.c
+++ b/Pi-Pico/pico_pqc_sdk/src/pqc_stats/stats.c
@@ -1,0 +1,56 @@
+#include "pqc-pico/stats.h"
+
+void init_stat(stat_t* st){
+    st->x = (float) 0;
+    st->x2 = (float) 0;
+    st->n = 0;
+}
+
+void add_stat(stat_t* st, float x){
+    st->x += x;
+    st->x2 += pow(x,2);
+    st->n+=1;
+}
+
+inline float mean_stat(stat_t* st){
+    return st->x / st->n;
+}
+
+static inline float __var_stat(stat_t* st){
+    return st->x2 / st->n - pow(mean_stat(st),2);
+}
+
+inline float sd_stat(stat_t* st){
+    return sqrt(__var_stat(st));
+}
+
+static inline float __sem_stat(stat_t* st){
+    return sd_stat(st) / sqrt(st->n);
+}
+
+float conf_stat(stat_t* st, int conf_pc){
+    float z;
+    switch(conf_pc){
+        case 50: z = 0.67449; break;
+        case 75: z = 1.15035; break;
+        case 90: z = 1.64485; break;
+        case 95: z = 1.95996; break;
+        case 97: z = 2.17009; break;
+        case 99: z = 2.57583; break;
+        case 999: z = 3.29053; break;
+        default: z = 1.95996; break;
+    }
+    return z * __sem_stat(st);
+} 
+
+inline void print_stat(stat_t* st){
+    printf("mean=%.3f sd=%.3f n=%zu\n",mean_stat(st),sd_stat(st),st->n);
+}
+
+inline void print_conf_stat(stat_t* st, int conf_pc){
+    printf("mean=%.3f ci=%.3f p=0.%d n=%zu\n",mean_stat(st),conf_stat(st,conf_pc),conf_pc,st->n);
+}
+
+void free_stat(stat_t* st){
+    free(st);
+}


### PR DESCRIPTION
add pqc_stats library including struct & helper functions for stat_t, stat_obj_t and csv_t, support for summary statistics mean, sd and confidence interval, plus generating csv output of labels and stats.